### PR TITLE
Fix unexpected closure

### DIFF
--- a/src/beginner/TabView.coffee
+++ b/src/beginner/TabView.coffee
@@ -1,7 +1,6 @@
 class @TabView
-  _index = 0
-
   constructor: (@$el) ->
+    @index = 0
     @$btns = @$el.querySelectorAll('.js-tab-btn')
     @$contents = @$el.querySelectorAll('.js-tab-content')
     @toggleBtn()
@@ -12,20 +11,20 @@ class @TabView
     for $btn, i in @$btns
       $btn.dataset.index = i
       $btn.addEventListener 'click', (e) =>
-        _index = +e.target.dataset.index
+        @index = +e.target.dataset.index
         @toggleBtn()
         @showContent()
 
   toggleBtn: ->
     for $btn, i in @$btns
-      if _index is i
+      if @index is i
         $btn.classList.add('is-active')
       else
         $btn.classList.remove('is-active')
 
   showContent: ->
     for $content, i in @$contents
-      if _index is i
+      if @index is i
         $content.classList.add('is-active')
       else
         $content.classList.remove('is-active')


### PR DESCRIPTION
`_index` variable is bound by `TabView` class statically.
I think that it is not necessary if there is no special reason.

What do you think?
