### PR TITLE
Remove black-magic from set method

### DIFF
--- a/src/intermediate/IntermediateModel.coffee
+++ b/src/intermediate/IntermediateModel.coffee
@@ -8,21 +8,25 @@ class @IntermediateModel
   get: (key) ->
     @[key]
 
-  set: (key, value, silent) ->
+  set: (key, value) ->
     @[key] = value
-    if not @_events[key] or silent
-      return
-    for callback in @_events[key]
-      (callback)()
+
+  on: (eventName, callback) ->
+    @_events[eventName] = @_events[eventName] or []
+    @_events[eventName].push(callback)
 
   onChange: (key, callback) ->
-    @_events[key] = @_events[key] or []
-    @_events[key].push(callback)
+    @on('change_' + key, callback)
+
+  emit: (eventName) ->
+    for callback in @_events[eventName]
+      callback()
 
   fetch: ->
     setTimeout( =>
       res = @genData()
       @set('data', res)
+      @emit('change_data')
     , 300)
 
   genData: ->


### PR DESCRIPTION
I think that `IntermediateModel#set` is wrong architecture by the following reasons:
1. "emit events or not" should not be selectable from View side
   - Many subscribers exist in other than these views, at the normal situation
2. `silent` flag looks complicated (to me)
   - It is not a general architecture?
